### PR TITLE
Remove IDEA branding from UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2,13 +2,13 @@
 <html>
 <head>
     <title>Service Monitor UI</title>
-    <link rel="icon" href="https://idea4industry.com/wp-content/uploads/cropped-IDEA-favicon-32x32.png">
+    <!-- Add link to project favicon here -->
     <style>
     body {
         font-family: Arial, sans-serif;
         margin: 0em;
         color: #ffffff;
-        background: url('https://wordpress.idea4industry.com/wp-content/uploads/AdobeStock_443793149-speed-blue-1536x922.jpg') no-repeat center center fixed;
+        background: url('https://wallpapercave.com/wp/fMos4cr.jpg') no-repeat center center fixed;
         background-size: cover;
     }
     table { border-collapse: collapse; }
@@ -20,8 +20,7 @@
     .page-header {
         display: flex;
         align-items: center;
-        gap: 35em;
-        background: url('https://wordpress.idea4industry.com/wp-content/uploads/AdobeStock_443793149-speed-blue-1536x922.jpg') no-repeat center center fixed;
+        background: url('https://wallpapercave.com/wp/fMos4cr.jpg') no-repeat center center fixed;
         background-size: cover;
         padding: 2.7em;
     }
@@ -42,7 +41,7 @@
         padding-left: 20em;
         padding-right: 20em;
         padding: 5em;
-        background: url('https://idea4industry.com/wp-content/uploads/AdobeStock_443793149-speed-white-1920x1152.png');
+        background: url('https://wallpapercave.com/wp/fMos4cr.jpg');
         background-size: cover;
     }
     .section {
@@ -122,9 +121,7 @@
 </head>
 <body>
 <header class="page-header">
-    <a href="https://idea4industry.com/">
-        <img src="https://wordpress.idea4industry.com/wp-content/uploads/IDEA-only-white-orange-01-768x200.png" alt="IDEA logo">
-    </a>
+    <!-- Insert project logo or navigation link here -->
     <h1>Service Monitor</h1>
 </header>
 <div class="sections">


### PR DESCRIPTION
## Summary
- replace IDEA-specific favicon, logo, and background imagery with placeholders and generic background

## Testing
- `pytest tests/test_login.py tests/test_monitor.py -q`
- `PYTHONPATH=. pytest tests/test_ui_server.py -q`
- `pytest tests/test_scheduler.py -q` *(fails: ModuleNotFoundError: No module named 'scheduler')*


------
https://chatgpt.com/codex/tasks/task_e_68bcb4fafdc083228ddb64b20456e204